### PR TITLE
fixes: norm and exp

### DIFF
--- a/ga.cs
+++ b/ga.cs
@@ -450,7 +450,7 @@ public class PGA3D
     /// Calculate the Euclidean norm. (strict positive).
     /// </summary>
     public float Norm() { 
-        return Mathf.Sqrt(Mathf.Abs((this * this.Conjugate())[0]));
+        return Mathf.Sqrt(Mathf.Abs((this * (~this))[0]));
     }
 
     /// <summary>

--- a/ga.cs
+++ b/ga.cs
@@ -531,8 +531,8 @@ public class PGA3D
             return Motor(1f, B[5], B[6], B[7], 0f, 0f, 0f, 0f);
         }
         else {
-            float m = (B[0]*B[10] + B[1]*B[9] + B[2]*B[8]), a = Mathf.Sqrt(l), c = Mathf.Cos(a), s = Mathf.Sin(a)/a, t = m/l*(c-s);
-            return Motor(c, s*B[0] + t*B[10], s*B[1] + t*B[9], s*B[2] + t*B[8], s*B[8], s*B[9], s*B[10], m*s);
+            float m = (B[5]*B[10] + B[6]*B[9] + B[7]*B[8]), a = Mathf.Sqrt(l), c = Mathf.Cos(a), s = Mathf.Sin(a)/a, t = m/l*(c-s);
+            return Motor(c, s*B[5] + t*B[10], s*B[6] + t*B[9], s*B[7] + t*B[8], s*B[8], s*B[9], s*B[10], m*s);
         }
     }
 


### PR DESCRIPTION
Hello Hamish! Just wanted to contribute a couple minor fixes.

### Norm

I usually see norm calculated with the reverse rather than conjugate. The bivector website generated implementations use conjugate but that appears to be a mistake that [Enki acknowledged in discord](https://discord.com/channels/607264339480674324/1084169411419701359/1163901988564639764)

> that's wrong - should be the reverse .. I'll have to revisit that

### Exp

Some of the indices were relative to a 6 component bivector object (like in [this paper](https://arxiv.org/pdf/2206.07496)) rather than this 16 component PGA3D object. So now it correctly references e01, e02, and e03 instead of scalar, e0, and e1.